### PR TITLE
修复"其他规则"页面内部边栏无法独立滚动问题

### DIFF
--- a/ContextMenuMgr.Frontend/Views/OtherRulesPageView.xaml
+++ b/ContextMenuMgr.Frontend/Views/OtherRulesPageView.xaml
@@ -6,7 +6,8 @@
     xmlns:viewModels="clr-namespace:ContextMenuMgr.Frontend.ViewModels"
     xmlns:views="clr-namespace:ContextMenuMgr.Frontend.Views">
     <Grid>
-        <TabControl Margin="0,8,0,0">
+        <!-- Named for code-behind tab selection tracking to toggle outer ScrollViewer -->
+        <TabControl x:Name="MainTabControl" Margin="0,8,0,0">
             <TabItem>
                 <TabItem.Header>
                     <StackPanel Orientation="Horizontal">
@@ -102,14 +103,18 @@
                                         TextWrapping="Wrap" />
                                 </StackPanel>
 
-                                <ItemsControl
+                                <!-- ScrollViewer wrapping ItemsControl for independent right-panel scrolling.
+                                     ItemsControl has no built-in ScrollViewer, so we wrap it explicitly.
+                                     The outer DynamicScrollViewer is disabled in code-behind for this tab. -->
+                                <ScrollViewer
                                     Grid.Row="1"
                                     Margin="12,0,12,12"
-                                    Background="Transparent"
-                                    BorderThickness="0"
-                                    ItemsSource="{Binding SelectedEnhanceGroup.Items}"
-                                    ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                                    ScrollViewer.VerticalScrollBarVisibility="Auto">
+                                    HorizontalScrollBarVisibility="Disabled"
+                                    VerticalScrollBarVisibility="Auto">
+                                    <ItemsControl
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        ItemsSource="{Binding SelectedEnhanceGroup.Items}">
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate DataType="{x:Type viewModels:EnhanceMenuItemViewModel}">
                                             <Border
@@ -182,6 +187,7 @@
                                         </DataTemplate>
                                     </ItemsControl.ItemTemplate>
                                 </ItemsControl>
+                                </ScrollViewer>
                             </Grid>
                         </Border>
                     </Grid>
@@ -312,14 +318,18 @@
                                         Visibility="{Binding SelectedDetailedEditGroup.FilePath, Converter={StaticResource NullOrEmptyToVisibilityConverter}}" />
                                 </StackPanel>
 
-                                <ItemsControl
+                                <!-- ScrollViewer wrapping ItemsControl for independent right-panel scrolling.
+                                     ItemsControl has no built-in ScrollViewer, so we wrap it explicitly.
+                                     The outer DynamicScrollViewer is disabled in code-behind for this tab. -->
+                                <ScrollViewer
                                     Grid.Row="1"
                                     Margin="12,0,12,12"
-                                    Background="Transparent"
-                                    BorderThickness="0"
-                                    ItemsSource="{Binding SelectedDetailedEditGroup.Rules}"
-                                    ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                                    ScrollViewer.VerticalScrollBarVisibility="Auto">
+                                    HorizontalScrollBarVisibility="Disabled"
+                                    VerticalScrollBarVisibility="Auto">
+                                    <ItemsControl
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        ItemsSource="{Binding SelectedDetailedEditGroup.Rules}">
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate DataType="{x:Type viewModels:DetailedEditRuleViewModel}">
                                             <Border
@@ -384,6 +394,7 @@
                                         </DataTemplate>
                                     </ItemsControl.ItemTemplate>
                                 </ItemsControl>
+                                </ScrollViewer>
                             </Grid>
                         </Border>
                     </Grid>

--- a/ContextMenuMgr.Frontend/Views/OtherRulesPageView.xaml
+++ b/ContextMenuMgr.Frontend/Views/OtherRulesPageView.xaml
@@ -8,7 +8,7 @@
     <Grid>
         <!-- Named for code-behind tab selection tracking to toggle outer ScrollViewer -->
         <TabControl x:Name="MainTabControl" Margin="0,8,0,0">
-            <TabItem>
+            <TabItem Tag="EnhanceMenus">
                 <TabItem.Header>
                     <StackPanel Orientation="Horizontal">
                         <ui:SymbolIcon Margin="0,0,6,0" Symbol="Star24" />
@@ -212,7 +212,7 @@
                 </Grid>
             </TabItem>
 
-            <TabItem>
+            <TabItem Tag="DetailedEdit">
                 <TabItem.Header>
                     <StackPanel Orientation="Horizontal">
                         <ui:SymbolIcon Margin="0,0,6,0" Symbol="DocumentEdit24" />

--- a/ContextMenuMgr.Frontend/Views/OtherRulesPageView.xaml.cs
+++ b/ContextMenuMgr.Frontend/Views/OtherRulesPageView.xaml.cs
@@ -60,8 +60,10 @@ public partial class OtherRulesPageView : System.Windows.Controls.UserControl
     {
         if (_outerScrollViewer is null) return;
 
-        var selectedIndex = MainTabControl.SelectedIndex;
-        var needsDisable = selectedIndex is 0 or 1;
+        // var selectedIndex = MainTabControl.SelectedIndex;
+        // var needsDisable = selectedIndex is 0 or 1;
+        var selectedItem = (TabItem)MainTabControl.SelectedItem;
+        var needsDisable = selectedItem.Tag is "EnhanceMenus" or "DetailedEdit";
 
         // Only modify the property when the state actually changes to avoid layout thrashing
         if (needsDisable && !_isOuterScrollViewerDisabled)

--- a/ContextMenuMgr.Frontend/Views/OtherRulesPageView.xaml.cs
+++ b/ContextMenuMgr.Frontend/Views/OtherRulesPageView.xaml.cs
@@ -1,15 +1,100 @@
-﻿namespace ContextMenuMgr.Frontend.Views;
+﻿using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace ContextMenuMgr.Frontend.Views;
 
 /// <summary>
 /// Represents the other Rules Page View.
 /// </summary>
 public partial class OtherRulesPageView : System.Windows.Controls.UserControl
 {
+    // WPF-UI's NavigationView wraps page content in a DynamicScrollViewer that gives
+    // content infinite height, causing split-panel tabs to scroll together instead of
+    // independently. We disable this outer ScrollViewer for split-panel tabs so that
+    // the content height is constrained to the viewport, allowing inner ScrollViewers
+    // (ListView built-in and the one wrapping ItemsControl) to work independently.
+    private ScrollViewer? _outerScrollViewer;
+    private ScrollBarVisibility _originalVerticalScrollBarVisibility;
+    private bool _isOuterScrollViewerDisabled;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="OtherRulesPageView"/> class.
     /// </summary>
     public OtherRulesPageView()
     {
         InitializeComponent();
+        Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
+        MainTabControl.SelectionChanged += OnTabSelectionChanged;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        // Find the outer DynamicScrollViewer injected by WPF-UI NavigationView
+        _outerScrollViewer = FindParentScrollViewer(this);
+        if (_outerScrollViewer is null) return;
+
+        _originalVerticalScrollBarVisibility = _outerScrollViewer.VerticalScrollBarVisibility;
+        UpdateOuterScrollViewer();
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        // Restore the outer ScrollViewer when navigating away so other pages are unaffected
+        RestoreOuterScrollViewer();
+        _outerScrollViewer = null;
+    }
+
+    private void OnTabSelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        UpdateOuterScrollViewer();
+    }
+
+    /// <summary>
+    /// Toggles the outer ScrollViewer based on the currently selected tab.
+    /// Split-panel tabs (EnhanceMenus=0, DetailedEdit=1) need it disabled
+    /// so left/right panels scroll independently. Other tabs need it enabled.
+    /// </summary>
+    private void UpdateOuterScrollViewer()
+    {
+        if (_outerScrollViewer is null) return;
+
+        var selectedIndex = MainTabControl.SelectedIndex;
+        var needsDisable = selectedIndex is 0 or 1;
+
+        // Only modify the property when the state actually changes to avoid layout thrashing
+        if (needsDisable && !_isOuterScrollViewerDisabled)
+        {
+            _outerScrollViewer.VerticalScrollBarVisibility = ScrollBarVisibility.Disabled;
+            _isOuterScrollViewerDisabled = true;
+        }
+        else if (!needsDisable && _isOuterScrollViewerDisabled)
+        {
+            _outerScrollViewer.VerticalScrollBarVisibility = _originalVerticalScrollBarVisibility;
+            _isOuterScrollViewerDisabled = false;
+        }
+    }
+
+    private void RestoreOuterScrollViewer()
+    {
+        if (_outerScrollViewer is null || !_isOuterScrollViewerDisabled) return;
+
+        _outerScrollViewer.VerticalScrollBarVisibility = _originalVerticalScrollBarVisibility;
+        _isOuterScrollViewerDisabled = false;
+    }
+
+    /// <summary>
+    /// Walks up the visual tree to find the first parent ScrollViewer.
+    /// </summary>
+    private static ScrollViewer? FindParentScrollViewer(DependencyObject child)
+    {
+        var parent = VisualTreeHelper.GetParent(child);
+        while (parent is not null)
+        {
+            if (parent is ScrollViewer sv) return sv;
+            parent = VisualTreeHelper.GetParent(parent);
+        }
+        return null;
     }
 }


### PR DESCRIPTION
这个bug修复方案，是借助了GLM-5.1vibe coding去验证了一下我自己的想法，作者你看看有没有什么地方可以再优化的
### BUG原因分析
WPF-UI 的 NavigationView 在 NavigationViewContentPresenter 内部自动注入了一个 DynamicScrollViewer ，包裹了整个页面内容。这个外层 ScrollViewer 给内容提供了 无限高度 ，导致：

- 左侧 ListView 的内置 ScrollViewer 无法被激活
- 右侧 ItemsControl 的内容无限撑高
- 只有一个外层 ScrollViewer 在工作 → 整个页面一起滚动
### 修复方案（两个文件配合）
1. OtherRulesPageView.xaml.cs — 智能控制外层 ScrollViewer

- 页面加载时，沿可视树向上找到外层 DynamicScrollViewer
- 分栏 Tab（索引 0、1） ：禁用外层 ScrollViewer 的垂直滚动 → 内容高度被约束到视口 → 内部 ScrollViewer 激活，左右独立滚动
- 其他 Tab（索引 2-6） ：恢复外层 ScrollViewer → 正常整体滚动
- Tab 切换时按需切换状态，仅在状态实际变化时修改属性，避免布局抖动
- 页面卸载时恢复原始状态，不影响其他页面
2. OtherRulesPageView.xaml — 右侧面板添加 ScrollViewer

- ItemsControl 没有内置 ScrollViewer，用 <ScrollViewer> 包裹使其具备独立滚动能力
- TabControl 添加 x:Name="MainTabControl" 供 code-behind 引用